### PR TITLE
Add example Tailscale subnet-router deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ The observer expects to run in a context with a working Kubernetes configuration
 The environment variable `TARGET_NAMESPACE` must be set to the namespace in which the observer should watch services.
 The environment variable `TAILSCALE_API_URL` can be used to provide a custom URL for the Tailscale client's HTTP API.
 By default, the observer expects the API to be reachable at `http://localhost:8088`.
+
+See the [subnet-router.yaml](./examples/subnet-router.yaml) for an example deployment.

--- a/examples/subnet-router.yaml
+++ b/examples/subnet-router.yaml
@@ -1,0 +1,164 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tailscale
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tailscale
+data: {}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tailscale-auth
+stringData:
+  # Set to a Auth key for the desired tailnet generated in the Tailscale admin panel
+  TS_AUTH_KEY: <YOUR-TS-AUTH-KEY>
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - tailscale
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tailscale
+subjects:
+  - kind: ServiceAccount
+    name: tailscale
+roleRef:
+  kind: Role
+  name: tailscale
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tailscale-namespace-router
+spec:
+  minReadySeconds: 15
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: tailscale-namespace-router
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: tailscale-namespace-router
+    spec:
+      containers:
+        - env:
+            - name: TS_KUBE_SECRET
+              value: tailscale
+            - name: TS_USERSPACE
+              value: "true"
+            - name: TS_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: TS_AUTH_KEY
+                  name: tailscale-auth
+                  optional: true
+            - name: HOME
+              value: /home/tailscale
+            - name: TS_SOCKET
+              value: /var/run/tailscaled/tailscaled.sock
+          image: ghcr.io/tailscale/tailscale:latest
+          name: tailscale
+          resources:
+            requests:
+              cpu: 40m
+              memory: 200Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - NET_BIND_SERVICE
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /home/tailscale
+              name: home
+            - mountPath: /var/run/tailscaled
+              name: socket
+        - command:
+            - /usr/local/bin/tailscale
+            - --socket=/var/run/tailscaled/tailscaled.sock
+            - web
+          image: ghcr.io/tailscale/tailscale:latest
+          name: tailscale-web
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - NET_BIND_SERVICE
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /var/run/tailscaled
+              name: socket
+        - image: ghcr.io/appuio/tailscale-service-observer:latest
+          env:
+            - name: TARGET_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          name: service-observer
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - NET_BIND_SERVICE
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /home/tailscale
+              name: home
+      serviceAccountName: tailscale
+      volumes:
+        - emptyDir: {}
+          name: home
+        - emptyDir: {}
+          name: socket


### PR DESCRIPTION
## Summary

Showcase how the service-observer can be used to dynamically advertise services in a tailnet.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
