### PR TITLE
Add support for watching events in multiple namespaces 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ You can specify multiple namespaces separated by commas.
 The environment variable `TAILSCALE_API_URL` can be used to provide a custom URL for the Tailscale client's HTTP API.
 By default, the observer expects the API to be reachable at `http://localhost:8088`.
 
-See the [subnet-router.yaml](./examples/subnet-router.yaml) for an example deployment.
+See the [examples](./examples/) for Kubernetes manifests to get started.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Tailscale service observer is a Go tool which watches Kubernetes services in a s
 
 The observer expects to run in a context with a working Kubernetes configuration (either via kubeconfig file or in-cluster).
 
-The environment variable `TARGET_NAMESPACE` must be set to the namespace in which the observer should watch services.
+The environment variable `TARGET_NAMESPACE` must be set to the namespace(s) in which the observer should watch services.
+You can specify multiple namespaces separated by commas.
 The environment variable `TAILSCALE_API_URL` can be used to provide a custom URL for the Tailscale client's HTTP API.
 By default, the observer expects the API to be reachable at `http://localhost:8088`.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,41 @@
+# Single namespace deployment
+
+Before you apply the manifests, you must set the `TS_AUTH_KEY` in `subnet-router.yaml`.
+
+```
+NAMESPACE=<tailscale-namespace> # replace with the namespace in which you want to deploy the Tailscale router
+kubectl create namespace "${NAMESPACE}"
+kubectl -n "${NAMESPACE}" apply -f subnet-router.yaml
+```
+
+# Watch for services in an additional namespace
+
+Setup RBAC in the additional namespace:
+
+```
+NAMESPACE=<tailscale-namespace> # the namespace in which the Tailscale router runs
+TARGET_NAMESPACE=<target-namespace> # the namespace in which you want to discover services
+sed "s/TS_NAMESPACE/${NAMESPACE}/" additional_ns_rbac.yaml | \
+  kubectl -n "${TARGET_NAMESPACE}" apply f -
+```
+
+Patch the router deployment:
+
+```
+sed "s/TS_NAMESPACE/${NAMESPACE}/" deploy-patch.json | \
+sed "s/ADD_NAMESPACE/${TARGET_NAMESPACE}/" >deploy-patch-${TARGET_NAMESPACE}.json
+
+kubectl -n "${NAMESPACE}" patch deploy/tailscale-namespace-router \
+  --type=json \
+  --patch-file=deploy-patch-${TARGET_NAMESPACE}.json
+```
+
+Please note that the patch expects that the Tailscale router deployment
+matches the deployment provided in this directory and will completely remove and replace the existing `TARGET_NAMESPACE` environment variable for the service-observer container with
+
+```
+- name: TARGET_NAMESPACE
+  value: ${NAMESPACE},${TARGET_NAMESPACE}
+```
+
+Please modify the deployment manually (for example with `kubectl edit`) if you want to add multiple additional namespaces.

--- a/examples/additional_ns_rbac.yaml
+++ b/examples/additional_ns_rbac.yaml
@@ -1,0 +1,28 @@
+# RBAC rules for allowing the observer to access an additional namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tailscale
+subjects:
+  - kind: ServiceAccount
+    name: tailscale
+    namespace: TS_NAMESPACE
+roleRef:
+  kind: Role
+  name: tailscale
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/deploy-patch-hackday-tailscale-2.json
+++ b/examples/deploy-patch-hackday-tailscale-2.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "remove",
+    "path": "/spec/template/spec/containers/2/env/0"
+  },
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/2/env/0",
+    "value": {
+      "name": "TARGET_NAMESPACE",
+      "value": "hackday-tailscale,hackday-tailscale-2"
+    }
+  }
+]

--- a/examples/deploy-patch.json
+++ b/examples/deploy-patch.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "remove",
+    "path": "/spec/template/spec/containers/2/env/0"
+  },
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/2/env/0",
+    "value": {
+      "name": "TARGET_NAMESPACE",
+      "value": "TS_NAMESPACE,ADD_NAMESPACE"
+    }
+  }
+]

--- a/main.go
+++ b/main.go
@@ -45,6 +45,18 @@ func createClient() (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(config)
 }
 
+func parseNamespaces(raw string) []string {
+	parts := strings.Split(raw, ",")
+	targetNamespaces := []string{}
+	for _, ns := range parts {
+		trimmed := strings.Trim(ns, " ")
+		if trimmed != "" {
+			targetNamespaces = append(targetNamespaces, trimmed)
+		}
+	}
+	return targetNamespaces
+}
+
 func main() {
 	// use controller-runtime to setup logging and context
 	opts := zap.Options{
@@ -60,7 +72,7 @@ func main() {
 		setupLog.Error(fmt.Errorf("TARGET_NAMESPACE not set"), "Unable to read target namespace from environment ($TARGET_NAMESPACE)")
 		os.Exit(1)
 	}
-	targetNamespaces := strings.Split(rawTargetNamespace, ",")
+	targetNamespaces := parseNamespaces(rawTargetNamespace)
 
 	var apiURL string
 	apiURL, ok = os.LookupEnv("TAILSCALE_API_URL")

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parseNamespaces(t *testing.T) {
+	tcases := []struct {
+		raw      string
+		expected []string
+	}{
+		{raw: "foo", expected: []string{"foo"}},
+		{raw: "foo,", expected: []string{"foo"}},
+		{raw: ", foo, ", expected: []string{"foo"}},
+		{raw: "foo,bar", expected: []string{"foo", "bar"}},
+		{raw: "foo, bar", expected: []string{"foo", "bar"}},
+		{raw: "foo, bar, ", expected: []string{"foo", "bar"}},
+	}
+
+	for _, tc := range tcases {
+		parsed := parseNamespaces(tc.raw)
+		assert.Equal(t, tc.expected, parsed)
+	}
+}

--- a/tailscaleupdater/updater.go
+++ b/tailscaleupdater/updater.go
@@ -24,7 +24,7 @@ type TailscaleAdvertisementUpdater struct {
 
 // NewTailscaleAdvertisementUpdater creates an updater with the given URL if
 // a GET request to the root path returns StatusOK
-func NewTailscaleAdvertisementUpdater(namespace, url string) (*TailscaleAdvertisementUpdater, error) {
+func NewTailscaleAdvertisementUpdater(namespaces []string, url string) (*TailscaleAdvertisementUpdater, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("Error querying Tailscale API at %s: %v", url, err)
@@ -36,7 +36,7 @@ func NewTailscaleAdvertisementUpdater(namespace, url string) (*TailscaleAdvertis
 	return &TailscaleAdvertisementUpdater{
 		URL:    url,
 		routes: map[string]struct{}{},
-		logger: ctrl.Log.WithName("tailscaleUpdater").WithValues("API URL", url, "namespace", namespace),
+		logger: ctrl.Log.WithName("tailscaleUpdater").WithValues("API URL", url, "namespaces", strings.Join(namespaces, ",")),
 	}, nil
 }
 

--- a/tailscaleupdater/updater_test.go
+++ b/tailscaleupdater/updater_test.go
@@ -18,13 +18,13 @@ import (
 func Test_NewTailscaleAdvertisementUpdater(t *testing.T) {
 	url := tsAPIServer()
 
-	tsUpdater, err := NewTailscaleAdvertisementUpdater("foo", url)
+	tsUpdater, err := NewTailscaleAdvertisementUpdater([]string{"foo"}, url)
 	assert.NoError(t, err)
 	assert.Equal(t, url, tsUpdater.URL)
 }
 
 func Test_NewTailscaleAdvertisementUpdater_NoService(t *testing.T) {
-	tsUpdater, err := NewTailscaleAdvertisementUpdater("foo", "")
+	tsUpdater, err := NewTailscaleAdvertisementUpdater([]string{"foo"}, "")
 	assert.Error(t, err)
 	assert.Nil(t, tsUpdater)
 }


### PR DESCRIPTION
## Summary
 
With the current implementation, we can't run multiple observer instances against the same Tailscale client, as they'll overwrite each other's route advertisements.

Instead, we add support for watching multiple namespaces to the observer. Multiple namespaces can be configured as a comma-separated list in environment variable `TARGET_NAMESPACE`.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
