### PR TITLE
Add support for advertising additional routes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,17 @@ The environment variable `TARGET_NAMESPACE` must be set to the namespace(s) in w
 You can specify multiple namespaces separated by commas.
 The environment variable `TAILSCALE_API_URL` can be used to provide a custom URL for the Tailscale client's HTTP API.
 By default, the observer expects the API to be reachable at `http://localhost:8088`.
+The environment variable `OBSERVER_ADDITIONAL_ROUTES` can be used to advertise additional routes.
+You can specify multiple routes separated by commas.
+Entries which can be parsed as an IP address will be advertised as a `<ip-address>/32` route.
+Entries which can be parsed as a CIDR prefix will be advertised as that prefix route.
 
 See the [examples](./examples/) for Kubernetes manifests to get started.
+
+## Expose the in-cluster DNS server in your tailnet
+
+To expose the in-cluster DNS server in your tailnet, you can advertise the in-cluster DNS IP address by adding it in the environment variable `OBSERVER_ADDITIONAL_ROUTES`.
+
+Additionally, you can enable Tailscale's MagicDNS feature, and add the in-cluster DNS server as an additional resolver.
+We recommend that you enable "Restrict to search domain", and set `svc.cluster.local` as the search domain.
+This allows you to use the in-cluster service DNS names (`<service>.<namespace>.svc.cluster.local`) to access advertised services.

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func main() {
 	if !ok {
 		apiURL = defaultTailscaleAPIURL
 	}
-	tsUpdater, err := tailscaleupdater.NewTailscaleAdvertisementUpdater(targetNamespaces, apiURL)
+	tsUpdater, err := tailscaleupdater.New(targetNamespaces, apiURL)
 
 	additionalRoutes, ok := os.LookupEnv("OBSERVER_ADDITIONAL_ROUTES")
 	if ok {

--- a/main.go
+++ b/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"flag"
-	"fmt"
+	"net/netip"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/appuio/tailscale-service-observer/tailscaleupdater"
+	"github.com/go-logr/logr"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -45,16 +46,41 @@ func createClient() (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(config)
 }
 
-func parseNamespaces(raw string) []string {
+// parseEnv parses comma-separated values from an env variable
+func parseEnv(raw string) []string {
 	parts := strings.Split(raw, ",")
-	targetNamespaces := []string{}
+	parsed := []string{}
 	for _, ns := range parts {
 		trimmed := strings.Trim(ns, " ")
 		if trimmed != "" {
-			targetNamespaces = append(targetNamespaces, trimmed)
+			parsed = append(parsed, trimmed)
 		}
 	}
-	return targetNamespaces
+	return parsed
+}
+
+func advertiseAdditionalRoutes(l logr.Logger, t *tailscaleupdater.TailscaleAdvertisementUpdater, rawRoutes string) {
+	for _, rspec := range parseEnv(rawRoutes) {
+		r, err := netip.ParsePrefix(rspec)
+		if err != nil {
+			a, err2 := netip.ParseAddr(rspec)
+			if err2 == nil {
+				r2, err2 := a.Prefix(a.BitLen())
+				if err2 != nil {
+					l.Error(err, "converting bare IP to prefix")
+				}
+				r = r2
+				err = err2
+			}
+		}
+		if err != nil {
+			l.Info("Failed to parse additional route, ignoring", "value", rspec)
+			continue
+		}
+		if err := t.AddRoute(r.String()); err != nil {
+			l.Error(err, "adding additional route", "route", r.String())
+		}
+	}
 }
 
 func main() {
@@ -65,23 +91,28 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctx := ctrl.SetupSignalHandler()
 	setupLog := ctrl.Log.WithName("setup")
 
 	rawTargetNamespace, ok := os.LookupEnv("TARGET_NAMESPACE")
 	if !ok {
-		setupLog.Error(fmt.Errorf("TARGET_NAMESPACE not set"), "Unable to read target namespace from environment ($TARGET_NAMESPACE)")
+		setupLog.Info("Unable to read target namespace from environment ($TARGET_NAMESPACE)")
 		os.Exit(1)
 	}
-	targetNamespaces := parseNamespaces(rawTargetNamespace)
+	targetNamespaces := parseEnv(rawTargetNamespace)
 
 	var apiURL string
 	apiURL, ok = os.LookupEnv("TAILSCALE_API_URL")
 	if !ok {
 		apiURL = defaultTailscaleAPIURL
 	}
+	tsUpdater, err := tailscaleupdater.NewTailscaleAdvertisementUpdater(targetNamespaces, apiURL)
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-	ctx := ctrl.SetupSignalHandler()
+	additionalRoutes, ok := os.LookupEnv("OBSERVER_ADDITIONAL_ROUTES")
+	if ok {
+		advertiseAdditionalRoutes(setupLog, tsUpdater, additionalRoutes)
+	}
 
 	client, err := createClient()
 	if err != nil {
@@ -89,7 +120,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	tsUpdater, err := tailscaleupdater.NewTailscaleAdvertisementUpdater(targetNamespaces, apiURL)
 	if err != nil {
 		setupLog.Error(err, "while creating Tailscale updater")
 		os.Exit(1)

--- a/main_test.go
+++ b/main_test.go
@@ -6,11 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_parseNamespaces(t *testing.T) {
+func Test_parseEnv(t *testing.T) {
 	tcases := []struct {
 		raw      string
 		expected []string
 	}{
+		{raw: "", expected: []string{}},
 		{raw: "foo", expected: []string{"foo"}},
 		{raw: "foo,", expected: []string{"foo"}},
 		{raw: ", foo, ", expected: []string{"foo"}},
@@ -20,7 +21,7 @@ func Test_parseNamespaces(t *testing.T) {
 	}
 
 	for _, tc := range tcases {
-		parsed := parseNamespaces(tc.raw)
+		parsed := parseEnv(tc.raw)
 		assert.Equal(t, tc.expected, parsed)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"testing"
 
+	"github.com/appuio/tailscale-service-observer/tailscaleupdater"
+	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,8 +16,7 @@ func Test_parseEnv(t *testing.T) {
 		{raw: "", expected: []string{}},
 		{raw: "foo", expected: []string{"foo"}},
 		{raw: "foo,", expected: []string{"foo"}},
-		{raw: ", foo, ", expected: []string{"foo"}},
-		{raw: "foo,bar", expected: []string{"foo", "bar"}},
+		{raw: ", foo, ", expected: []string{"foo"}}, {raw: "foo,bar", expected: []string{"foo", "bar"}},
 		{raw: "foo, bar", expected: []string{"foo", "bar"}},
 		{raw: "foo, bar, ", expected: []string{"foo", "bar"}},
 	}
@@ -23,5 +24,58 @@ func Test_parseEnv(t *testing.T) {
 	for _, tc := range tcases {
 		parsed := parseEnv(tc.raw)
 		assert.Equal(t, tc.expected, parsed)
+	}
+}
+
+func Test_advertiseAdditionalRoutes(t *testing.T) {
+	l := testr.New(t)
+
+	tcases := map[string]struct {
+		raw      string
+		expected map[string]struct{}
+	}{
+		"empty": {
+			raw:      "",
+			expected: map[string]struct{}{},
+		},
+		"ip": {
+			raw: "198.51.100.1",
+			expected: map[string]struct{}{
+				"198.51.100.1/32": {},
+			},
+		},
+		"multiple_ip": {
+			raw: "198.51.100.1, 198.51.100.2",
+			expected: map[string]struct{}{
+				"198.51.100.1/32": {},
+				"198.51.100.2/32": {},
+			},
+		},
+		"prefix": {
+			raw: "198.51.100.0/29",
+			expected: map[string]struct{}{
+				"198.51.100.0/29": {},
+			},
+		},
+		"multiple_prefix": {
+			raw: "198.51.100.0/29,198.51.100.128/29",
+			expected: map[string]struct{}{
+				"198.51.100.0/29":   {},
+				"198.51.100.128/29": {},
+			},
+		},
+		"mixed": {
+			raw: "198.51.100.1,198.51.100.128/29",
+			expected: map[string]struct{}{
+				"198.51.100.1/32":   {},
+				"198.51.100.128/29": {},
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		tsUpdater := tailscaleupdater.NewUnchecked([]string{"test"}, "foobar", l)
+		advertiseAdditionalRoutes(l, tsUpdater, tc.raw)
+		assert.Equal(t, tsUpdater.GetRoutes(), tc.expected)
 	}
 }

--- a/tailscaleupdater/updater.go
+++ b/tailscaleupdater/updater.go
@@ -22,9 +22,9 @@ type TailscaleAdvertisementUpdater struct {
 	logger logr.Logger
 }
 
-// NewTailscaleAdvertisementUpdater creates an updater with the given URL if
-// a GET request to the root path returns StatusOK
-func NewTailscaleAdvertisementUpdater(namespaces []string, url string) (*TailscaleAdvertisementUpdater, error) {
+// New creates a new updater with the given URL if a GET request to the root
+// path returns StatusOK
+func New(namespaces []string, url string) (*TailscaleAdvertisementUpdater, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("Error querying Tailscale API at %s: %v", url, err)

--- a/tailscaleupdater/updater.go
+++ b/tailscaleupdater/updater.go
@@ -40,6 +40,16 @@ func New(namespaces []string, url string) (*TailscaleAdvertisementUpdater, error
 	}, nil
 }
 
+// NewUnchecked creates a new updater without validating the provided
+// configuration. Primarily intended for tests
+func NewUnchecked(namespaces []string, url string, l logr.Logger) *TailscaleAdvertisementUpdater {
+	return &TailscaleAdvertisementUpdater{
+		URL:    url,
+		routes: map[string]struct{}{},
+		logger: l,
+	}
+}
+
 // SetupInformer creates a services informer on the given informer factory,
 // and sets up a handler which updates the Tailscale route advertisements
 func (t *TailscaleAdvertisementUpdater) SetupInformer(informerFactory informers.SharedInformerFactory) cache.SharedIndexInformer {
@@ -61,6 +71,10 @@ func (t *TailscaleAdvertisementUpdater) AddRoute(route string) error {
 		return t.post()
 	}
 	return nil
+}
+
+func (t *TailscaleAdvertisementUpdater) GetRoutes() map[string]struct{} {
+	return t.routes
 }
 
 func (t *TailscaleAdvertisementUpdater) informerAddHandler(obj interface{}) {

--- a/tailscaleupdater/updater_test.go
+++ b/tailscaleupdater/updater_test.go
@@ -15,16 +15,16 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func Test_NewTailscaleAdvertisementUpdater(t *testing.T) {
+func Test_New(t *testing.T) {
 	url := tsAPIServer()
 
-	tsUpdater, err := NewTailscaleAdvertisementUpdater([]string{"foo"}, url)
+	tsUpdater, err := New([]string{"foo"}, url)
 	assert.NoError(t, err)
 	assert.Equal(t, url, tsUpdater.URL)
 }
 
-func Test_NewTailscaleAdvertisementUpdater_NoService(t *testing.T) {
-	tsUpdater, err := NewTailscaleAdvertisementUpdater([]string{"foo"}, "")
+func Test_New_NoService(t *testing.T) {
+	tsUpdater, err := New([]string{"foo"}, "")
 	assert.Error(t, err)
 	assert.Nil(t, tsUpdater)
 }


### PR DESCRIPTION
## Summary

Implement environment variable `OBSERVER_ADDITIONAL_ROUTES` which can be used to configure additional routes (accepted values: bare IP addresses or prefixes) which are configured as advertised routes on the Tailscale client.

If bare IP addresses are provided, the corresponding `/32` (or `/128` for IPv6) is configured as the route.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
